### PR TITLE
Add weather notifier script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,59 @@
+# Discord Webhook Utilities
 
+This repository contains Node.js scripts that send notifications to Discord using webhooks.
 
-# Discord Webhook Monitor
+## Scripts
+- `scripts/access_rakuten.js`: Monitors a Rakuten page and notifies when a specific button appears.
+- `scripts/weather_notifier.js`: Sends the current weather for a specified location.
 
-Rakutenサイトの特定ページを監視し、条件を満たすとDiscord Webhookに通知するスクリプトです。
+## Setup
 
-## 使用技術
-
-- Node.js
-- Puppeteer
-- dotenv
-
-## セットアップ手順
-
-1. 依存パッケージのインストール：
+1. Install dependencies:
 
 ```bash
 npm install
 ```
 
-2. `.env` ファイルの作成：
+2. Create a `.env` file:
 
 ```env
-MONITOR_URL=https://対象のURL
 WEBHOOK_URL=https://discord.com/api/webhooks/xxxxxxxxx/xxxxxxxxx
+MONITOR_URL=https://example.com
+MONITOR_LABEL=Example
+WEATHER_LAT=35.68
+WEATHER_LON=139.76
+WEATHER_CITY=Tokyo
 ```
 
-3. Chromeのインストール（Puppeteer用）：
+3. Install Chrome for Puppeteer:
 
 ```bash
 npx puppeteer browsers install chrome
 ```
 
-## 実行方法
+## Usage
 
-### 通常実行
+### Monitor Rakuten page
 
 ```bash
 node scripts/access_rakuten.js
 ```
 
-### バックグラウンドで実行（ログは monitor.log に出力）
+Run in background:
 
 ```bash
 nohup node scripts/access_rakuten.js > monitor.log 2>&1 &
 ```
 
-## トラブルシューティング
+### Send weather notification
 
-- Raspberry PiなどARM環境では、Puppeteer用Chromeのバイナリが対応していない可能性があります。
-- `chrome` 実行時のエラーが出る場合は、対応するChromeバイナリを手動でインストールするか、x86環境での実行を検討してください。
+```bash
+node scripts/weather_notifier.js
+```
+
+You can schedule this with cron for daily updates.
+
+## Troubleshooting
+
+- On ARM environments like Raspberry Pi, the Puppeteer Chrome binary may not be available.
+- If `chrome` fails to start, install a compatible Chrome manually or consider using an x86 environment.

--- a/scripts/weather_notifier.js
+++ b/scripts/weather_notifier.js
@@ -1,0 +1,40 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import fetch from 'node-fetch';
+
+const webhookUrl = process.env.WEBHOOK_URL;
+const latitude = process.env.WEATHER_LAT;
+const longitude = process.env.WEATHER_LON;
+const city = process.env.WEATHER_CITY || 'Your location';
+
+if (!webhookUrl) {
+  console.error('Discord Webhook URL is not defined in .env');
+  process.exit(1);
+}
+if (!latitude || !longitude) {
+  console.error('WEATHER_LAT and WEATHER_LON must be defined in .env');
+  process.exit(1);
+}
+
+async function sendWeather() {
+  const apiUrl = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true&timezone=Asia%2FTokyo`;
+  const res = await fetch(apiUrl);
+  if (!res.ok) {
+    throw new Error(`Weather API request failed with status ${res.status}`);
+  }
+  const data = await res.json();
+  const weather = data.current_weather;
+  const message = `${city}の現在の気温は${weather.temperature}°C、風速は${weather.windspeed}m/sです。`;
+
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: message })
+  });
+}
+
+sendWeather().catch(err => {
+  console.error('Error sending weather:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add weather_notifier.js example script to send current weather to a Discord webhook
- rewrite README with new usage instructions

## Testing
- `npm install` *(fails: registry.npmjs.org unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68790a18a698832fa82dd175e681520f